### PR TITLE
Fix PSA import via bpy

### DIFF
--- a/io_import_scene_unreal_psa_psk_280/io_import_scene_unreal_psa_psk_280.py
+++ b/io_import_scene_unreal_psa_psk_280/io_import_scene_unreal_psa_psk_280.py
@@ -2059,7 +2059,8 @@ class IMPORT_OT_psa(bpy.types.Operator, ImportProps):
                     "bToSRGB",
                     "filter_glob",
                     "files", 
-                    "directory"
+                    "directory",
+                    "bSmoothShade"
                     )
                 )) )
             return {'FINISHED'}


### PR DESCRIPTION
When importing PSA animations using blender python scripts, the bSmoothShade kwarg is passed to the function. This PR adds this kwarg to the ignored keyword arguments tuple.